### PR TITLE
spi.v: make code synthetizable

### DIFF
--- a/spi.v
+++ b/spi.v
@@ -202,6 +202,8 @@ module spi_periph (
               // Mask CS to hide implicit 9th edge caused by CS transition
               mask_cs <= 1'b1;
               state <= `ST_D_S;
+            end else begin
+              addr_o <= addr_o + 16'd1;
             end
           end
         end
@@ -214,7 +216,7 @@ module spi_periph (
           // Check miso_r instead of data_rd, it may arrive between negedge and here
           if (bit_counter === 3'd0 && miso_r === 1'b1) begin
             data_req <= 1'b0;
-            //size <= size - 2'd1;
+            addr_o <= addr_o + 16'd1;
             state <= `ST_READ;
           end
         end
@@ -228,6 +230,7 @@ module spi_periph (
             byte <= data_i;
             data_req <= 1'b0;
             size <= size - 2'd1;
+            addr_o <= addr_o + 16'd1;
             state <= `ST_READ;
             if (size === 2'd0) begin
               // Mask CS to hide implicit 9th edge caused by CS transition

--- a/spi.v
+++ b/spi.v
@@ -146,7 +146,7 @@ module spi_periph (
       case (state)
         `ST_D_S: begin
           data_req <= 0;
-          data_wr <= 0;
+          data_wr <= data_wr & ~wr_done;
           byte[bit_counter] <= mosi;
           if (bit_counter === 3'd0) begin
             direction <= byte[7];
@@ -193,6 +193,7 @@ module spi_periph (
         `ST_WRITE: begin
           byte[bit_counter] <= mosi;
           data_wr <= 1'b0;
+          data_req <= 1'b0;
           if (bit_counter === 3'd0) begin
             data_o <= {byte[7:1], mosi};
             data_wr <= 1'b1;

--- a/spi_module.svg
+++ b/spi_module.svg
@@ -49,7 +49,7 @@ width="460" height="205" viewBox="-99 -20 460.0 205.0" version="1.1">
 <g transform="translate(260,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt2" x="-10" y="0" text-anchor="end" dy="3.5">miso</text>
-<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
+<text class="fnt2" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
 </g>
 </g>
 <g transform="translate(0,87.0)">


### PR DESCRIPTION
Previously the code had negedge CS on sensitivity list, but then there was a conditional that checked for high CS level. Negedge on the sensitivity list was treated as reset signal, but the rest of the code was reversed with respect to it. There are no logic elements capable of implementing such logic, so the sensitivity list was changed to negedge of logical sum of clock and CS. In addition, MISO was changed from direct register output to wire gated by effective_cs, which as a side effect reduced the number of warnings about tri-state logic produced by Yosys.